### PR TITLE
Bugfix/sinan fix sass deprecation warnings

### DIFF
--- a/src/components/elements/ButtonCustom.vue
+++ b/src/components/elements/ButtonCustom.vue
@@ -39,6 +39,8 @@ const handleClick = () => {
 </script>
 
 <style lang="scss">
+@use 'sass:color';
+
 .button-custom-wrap {
   display: flex;
   justify-content: center;
@@ -73,11 +75,11 @@ const handleClick = () => {
   @media only screen and (min-width: 1024px) {
     // hover effect for desktop
     &:hover {
-      background-color: darken($secondary-color, 5%);
+      background-color: color.adjust($secondary-color, $lightness: -5%);
     }
     &.small-button {
       &:hover {
-        background-color: darken($primary-color, 7%);
+        background-color: color.adjust($primary-color, $lightness: -7%);
       }
     }
   }

--- a/src/components/elements/ListDropdown.vue
+++ b/src/components/elements/ListDropdown.vue
@@ -181,6 +181,8 @@ onUnmounted(() => {
 </script>
 
 <style scoped lang="scss">
+@use 'sass:color';
+
 .dropdown-container {
   position: relative;
   display: flex;
@@ -274,7 +276,7 @@ onUnmounted(() => {
         cursor: pointer;
 
         &:hover {
-          background-color: darken($secondary-color, 30%);
+          background-color: color.adjust($secondary-color, $lightness: -30%);
         }
       }
     }

--- a/src/components/widgets/DashboardHeader.vue
+++ b/src/components/widgets/DashboardHeader.vue
@@ -65,6 +65,8 @@ const handleLogout = () => {
 </script>
 
 <style lang="scss">
+@use 'sass:color';
+
 .dashboard-header {
   display: flex;
   flex-direction: column;
@@ -185,7 +187,7 @@ const handleLogout = () => {
           border-radius: 8px;
 
           &:hover {
-            background-color: lighten($dark-background, 5%);
+            background-color: color.adjust($dark-background, $lightness: 5%);
           }
 
           .user-icon {

--- a/src/components/widgets/ExpenseItem.vue
+++ b/src/components/widgets/ExpenseItem.vue
@@ -129,6 +129,8 @@ const handleEditExpense = () => {
 </script>
 
 <style lang="scss">
+@use 'sass:color';
+
 .expense-item {
   display: flex;
   align-items: center;
@@ -262,11 +264,11 @@ const handleEditExpense = () => {
   @media only screen and (min-width: 1024px) {
     cursor: pointer;
     &:hover:not(.expense-item-actions) {
-      background-color: lighten($dark-color-base, 5%);
+      background-color: color.adjust($dark-color-base, $lightness: 5%);
     }
     &.expense-item-actions {
       &:hover {
-        background-color: lighten($secondary-color, 40%);
+        background-color: color.adjust($secondary-color, $lightness: 40%);
       }
     }
   }

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -20,11 +20,11 @@ body {
 #app {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;  /* This ensures the app takes the full height of the screen */
+  min-height: 100vh; /* This ensures the app takes the full height of the screen */
 }
 
 .calculator-page {
-  flex-grow: 1;  /* This allows the main content to grow and fill the available space */
+  flex-grow: 1; /* This allows the main content to grow and fill the available space */
 }
 
 /* Global Styles */
@@ -108,26 +108,26 @@ body {
 }
 
 .error-message {
-    position: absolute;
-    top: 100%;
-    color: $error-color;
-    font-size: 0.875rem;
+  position: absolute;
+  top: 100%;
+  color: $error-color;
+  font-size: 0.875rem;
 
-    &.budget-exceeded {
-      text-align: center;
-      margin-top: 10px;
-      font-size: 20px;
-    }
-
-    &.landing-error-message {
-      display: flex;
-      justify-content: center;
-      margin-top: 10px;
-      font-size: 20px;
-      top: unset;
-      position: relative;
-    }
+  &.budget-exceeded {
+    text-align: center;
+    margin-top: 10px;
+    font-size: 20px;
   }
+
+  &.landing-error-message {
+    display: flex;
+    justify-content: center;
+    margin-top: 10px;
+    font-size: 20px;
+    top: unset;
+    position: relative;
+  }
+}
 
 /* Chrome, Safari, Edge, Opera */
 input::-webkit-outer-spin-button,
@@ -137,7 +137,7 @@ input::-webkit-inner-spin-button {
 }
 
 /* Firefox */
-input[type=number] {
+input[type='number'] {
   -moz-appearance: textfield;
   appearance: textfield;
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,14 +1,14 @@
 /* Color Variables */
-$light-color-base: #FBFBFB;
-$dark-color-base: #1E1E1E; // main-dsrk/base
-$box-color-light: #FFFDE7; // extras/box-color-light
-$primary-color: #51D289; // complementaries/compl-opt2
-$secondary-color: #FFE600; // complementaries/compl-opt1
-$error-color: #F44336; // extras/error
+$light-color-base: #fbfbfb;
+$dark-color-base: #1e1e1e; // main-dsrk/base
+$box-color-light: #fffde7; // extras/box-color-light
+$primary-color: #51d289; // complementaries/compl-opt2
+$secondary-color: #ffe600; // complementaries/compl-opt1
+$error-color: #f44336; // extras/error
 
-$border-dotted-color: #B2B2B2; // main-dsrk/main-10
+$border-dotted-color: #b2b2b2; // main-dsrk/main-10
 $border-solid-color: $box-color-light;
-$placeholder-color: #A3A3A3; // main-dsrk/main-20
+$placeholder-color: #a3a3a3; // main-dsrk/main-20
 $image-border-color: $primary-color;
 
 /* Background Variables */
@@ -22,18 +22,18 @@ $dark-text: $dark-color-base;
 $accent-text: $primary-color;
 $secondary-text: $secondary-color;
 $black-text: #000000;
-$white-text: #FFFFFF;
+$white-text: #ffffff;
 $subtitle-text: $secondary-color;
 
 /* Landing Page Variables */
 $landing-image-background: $box-color-light;
 
 /* Progress Bar Variables */
-$progress-bar-background: #D2D2D2;
+$progress-bar-background: #d2d2d2;
 $progress-bar-fill: $primary-color;
 
 /* Input Variables */
-$input-border-color: #FFFFFF;
+$input-border-color: #ffffff;
 
 /* Box Shadow Variables */
 $box-shadow-color: rgba($black-text, 0.05);


### PR DESCRIPTION
Updated all SCSS usages of darken() and lighten() to use color.adjust() from the sass:color module to remove deprecation warnings and prepare for future Dart Sass versions. Also added @use 'sass:color' where needed.

Additionally, formatted app.scss and variables.scss using Prettier for consistency.